### PR TITLE
Fix build instructions

### DIFF
--- a/promq/README.md
+++ b/promq/README.md
@@ -49,5 +49,5 @@ We use a standard go build to build from source code. You will want to move the 
 path. Assuming you have a `~/bin` directory in your `PATH`, the build would look like this:
  
 ```bash
-go build promq.go && cp promq ~/bin 
+go build -o ~/bin/promq promq.go
 ```


### PR DESCRIPTION
`go build promq.go` creates ``promq`` which is already a directory. See
error message below:

```
go build: build output "promq" already exists and is a directory
```
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:

Minor fix to the README.md on how to build/install the binary

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Does this PR introduce a user-facing change?**:
```release-note
NONE
```

**Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.**:

```docs

```

